### PR TITLE
Giving access to the commentOnlyChangedContentContext parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ job('GitLab_MR_Builder') {
     proxyCredentialsId('') // A username/password credential
  
     commentOnlyChangedContent(true)
+    commentOnlyChangedContentContext(0)
     commentOnlyChangedFiles(true)
     createSingleFileComments(true)
     createCommentWithAllSingleFileComments(true)
@@ -475,6 +476,7 @@ node {
   projectId: env.PROJECT_PATH,
   mergeRequestIid: env.MERGE_REQUST_IID,
   commentOnlyChangedContent: true,
+  commentOnlyChangedContentContext: 0,
   commentOnlyChangedFiles: true,
   createSingleFileComments: true,
   createCommentWithAllSingleFileComments: true,

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 		<findbugs.failOnError>false</findbugs.failOnError>
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<violations-maven>1.43</violations-maven>
-		<violation-comments-lib>1.86.3</violation-comments-lib>
+		<violation-comments-lib>1.86.4</violation-comments-lib>
 		<violations-lib>1.144.5</violations-lib>
 		<changelog>1.78</changelog>
 		<fmt>2.9</fmt>

--- a/sandbox/gitlab.com.testpipeline.jenkinsfile
+++ b/sandbox/gitlab.com.testpipeline.jenkinsfile
@@ -23,6 +23,7 @@ node {
     projectId: "2732496",
     mergeRequestIid: "1",
     commentOnlyChangedContent: true,
+    commentOnlyChangedContentContext: 0,
     commentOnlyChangedFiles: true,
     createCommentWithAllSingleFileComments: true, 
     minSeverity: 'INFO',

--- a/src/main/java/org/jenkinsci/plugins/jvctgl/config/ViolationsToGitLabConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctgl/config/ViolationsToGitLabConfig.java
@@ -28,6 +28,7 @@ public class ViolationsToGitLabConfig extends AbstractDescribableImpl<Violations
   private static final long serialVersionUID = 4851568645021422528L;
 
   private boolean commentOnlyChangedContent;
+  private Integer commentOnlyChangedContentContext = 0;
   private boolean commentOnlyChangedFiles = true;
   private boolean createCommentWithAllSingleFileComments;
   private boolean createSingleFileComments;
@@ -69,6 +70,7 @@ public class ViolationsToGitLabConfig extends AbstractDescribableImpl<Violations
     this.createCommentWithAllSingleFileComments = rhs.createCommentWithAllSingleFileComments;
     this.createSingleFileComments = rhs.createSingleFileComments;
     this.commentOnlyChangedContent = rhs.commentOnlyChangedContent;
+    this.commentOnlyChangedContentContext = rhs.commentOnlyChangedContentContext;
     this.commentOnlyChangedFiles = rhs.commentOnlyChangedFiles;
     this.gitLabUrl = rhs.gitLabUrl;
     this.projectId = rhs.projectId;
@@ -131,6 +133,10 @@ public class ViolationsToGitLabConfig extends AbstractDescribableImpl<Violations
 
   public boolean getCommentOnlyChangedContent() {
     return this.commentOnlyChangedContent;
+  }
+
+  public Integer getCommentOnlyChangedContentContext() {
+    return this.commentOnlyChangedContentContext;
   }
 
   public boolean getCreateCommentWithAllSingleFileComments() {
@@ -218,6 +224,11 @@ public class ViolationsToGitLabConfig extends AbstractDescribableImpl<Violations
   }
 
   @DataBoundSetter
+  public void setCommentOnlyChangedContentContext(final Integer commentOnlyChangedContentContext) {
+    this.commentOnlyChangedContentContext = commentOnlyChangedContentContext;
+  }
+
+  @DataBoundSetter
   public void setCommentOnlyChangedFiles(final boolean commentOnlyChangedFiles) {
     this.commentOnlyChangedFiles = commentOnlyChangedFiles;
   }
@@ -249,6 +260,7 @@ public class ViolationsToGitLabConfig extends AbstractDescribableImpl<Violations
     }
     final ViolationsToGitLabConfig that = (ViolationsToGitLabConfig) o;
     return this.commentOnlyChangedContent == that.commentOnlyChangedContent
+        && Objects.equals(this.commentOnlyChangedContentContext, that.commentOnlyChangedContentContext)
         && this.commentOnlyChangedFiles == that.commentOnlyChangedFiles
         && this.createCommentWithAllSingleFileComments
             == that.createCommentWithAllSingleFileComments
@@ -274,6 +286,7 @@ public class ViolationsToGitLabConfig extends AbstractDescribableImpl<Violations
   public int hashCode() {
     return Objects.hash(
         this.commentOnlyChangedContent,
+        this.commentOnlyChangedContentContext,
         this.commentOnlyChangedFiles,
         this.createCommentWithAllSingleFileComments,
         this.createSingleFileComments,
@@ -299,6 +312,8 @@ public class ViolationsToGitLabConfig extends AbstractDescribableImpl<Violations
     return "ViolationsToGitLabConfig{"
         + "commentOnlyChangedContent="
         + this.commentOnlyChangedContent
+        + "commentOnlyChangedContentContext="
+        + this.commentOnlyChangedContentContext
         + "commentOnlyChangedFiles="
         + this.commentOnlyChangedFiles
         + ", createCommentWithAllSingleFileComments="

--- a/src/main/java/org/jenkinsci/plugins/jvctgl/config/ViolationsToGitLabConfigHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctgl/config/ViolationsToGitLabConfigHelper.java
@@ -2,6 +2,7 @@ package org.jenkinsci.plugins.jvctgl.config;
 
 public class ViolationsToGitLabConfigHelper {
   public static final String FIELD_COMMENTONLYCHANGEDCONTENT = "commentOnlyChangedContent";
+  public static final String FIELD_COMMENTONLYCHANGEDCONTENTCONTEXT = "commentOnlyChangedContentContext";
   public static final String FIELD_CREATECOMMENTWITHALLSINGLEFILECOMMENTS =
       "createCommentWithAllSingleFileComments";
   public static final String FIELD_CREATESINGLEFILECOMMENTS = "createSingleFileComments";

--- a/src/main/java/org/jenkinsci/plugins/jvctgl/perform/JvctglPerformer.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctgl/perform/JvctglPerformer.java
@@ -3,18 +3,7 @@ package org.jenkinsci.plugins.jvctgl.perform;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Strings.nullToEmpty;
 import static java.util.logging.Level.SEVERE;
-import static org.jenkinsci.plugins.jvctgl.config.ViolationsToGitLabConfigHelper.FIELD_APITOKENCREDENTIALSID;
-import static org.jenkinsci.plugins.jvctgl.config.ViolationsToGitLabConfigHelper.FIELD_APITOKENPRIVATE;
-import static org.jenkinsci.plugins.jvctgl.config.ViolationsToGitLabConfigHelper.FIELD_AUTHMETHODHEADER;
-import static org.jenkinsci.plugins.jvctgl.config.ViolationsToGitLabConfigHelper.FIELD_COMMENTONLYCHANGEDCONTENT;
-import static org.jenkinsci.plugins.jvctgl.config.ViolationsToGitLabConfigHelper.FIELD_CREATECOMMENTWITHALLSINGLEFILECOMMENTS;
-import static org.jenkinsci.plugins.jvctgl.config.ViolationsToGitLabConfigHelper.FIELD_GITLABURL;
-import static org.jenkinsci.plugins.jvctgl.config.ViolationsToGitLabConfigHelper.FIELD_IGNORECERTIFICATEERRORS;
-import static org.jenkinsci.plugins.jvctgl.config.ViolationsToGitLabConfigHelper.FIELD_KEEP_OLD_COMMENTS;
-import static org.jenkinsci.plugins.jvctgl.config.ViolationsToGitLabConfigHelper.FIELD_MERGEREQUESTIID;
-import static org.jenkinsci.plugins.jvctgl.config.ViolationsToGitLabConfigHelper.FIELD_MINSEVERITY;
-import static org.jenkinsci.plugins.jvctgl.config.ViolationsToGitLabConfigHelper.FIELD_PROJECTID;
-import static org.jenkinsci.plugins.jvctgl.config.ViolationsToGitLabConfigHelper.FIELD_SHOULD_SET_WIP;
+import static org.jenkinsci.plugins.jvctgl.config.ViolationsToGitLabConfigHelper.*;
 import static se.bjurr.violations.comments.gitlab.lib.ViolationCommentsToGitLabApi.violationCommentsToGitLabApi;
 import static se.bjurr.violations.lib.ViolationsApi.violationsApi;
 
@@ -148,6 +137,7 @@ public class JvctglPerformer {
           .setApiToken(apiToken)
           .setTokenType(tokenType)
           .setCommentOnlyChangedContent(config.getCommentOnlyChangedContent())
+          .setCommentOnlyChangedContentContext(config.getCommentOnlyChangedContentContext())
           .withShouldCommentOnlyChangedFiles(config.getCommentOnlyChangedFiles())
           .setCreateCommentWithAllSingleFileComments(
               config.getCreateCommentWithAllSingleFileComments())
@@ -184,6 +174,7 @@ public class JvctglPerformer {
     expanded.setIgnoreCertificateErrors(config.getIgnoreCertificateErrors());
 
     expanded.setCommentOnlyChangedContent(config.getCommentOnlyChangedContent());
+    expanded.setCommentOnlyChangedContentContext(config.getCommentOnlyChangedContentContext());
     expanded.setCommentOnlyChangedFiles(config.getCommentOnlyChangedFiles());
     expanded.setCreateCommentWithAllSingleFileComments(
         config.getCreateCommentWithAllSingleFileComments());
@@ -298,6 +289,7 @@ public class JvctglPerformer {
             + config.getCreateCommentWithAllSingleFileComments());
     logger.println("createSingleFileComments" + ": " + config.getCreateSingleFileComments());
     logger.println(FIELD_COMMENTONLYCHANGEDCONTENT + ": " + config.getCommentOnlyChangedContent());
+    logger.println(FIELD_COMMENTONLYCHANGEDCONTENTCONTEXT + ": " + config.getCommentOnlyChangedContentContext());
     logger.println("commentOnlyChangedFiles: " + config.getCommentOnlyChangedFiles());
 
     logger.println("maxNumberOfViolations:" + config.getMaxNumberOfViolations());

--- a/src/main/resources/org/jenkinsci/plugins/jvctgl/config/ViolationsToGitLabConfig/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/jvctgl/config/ViolationsToGitLabConfig/config.jelly
@@ -94,6 +94,13 @@
     <f:checkbox />
   </f:entry>
 
+  <f:entry title="The number of context lines around changes" field="commentOnlyChangedContentContext">
+    <f:textbox />
+    <f:description>
+     This is the number of context lines around the changes that you want to comment on.
+    </f:description>
+  </f:entry>
+
   <f:entry title="Comment only changed files" field="commentOnlyChangedFiles">
     <f:checkbox />
   </f:entry>


### PR DESCRIPTION
This is pretty much for exposing te commentOnlyChangedContentContext parameter. Hope I did not mess it up, had to do mostly search and replace, me and maven are not good friends. If I messed up the change let me know what and how I can better test before submitting. 